### PR TITLE
Changed the default FadeButton behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## **0.7.3** - 28 nov 2022.
+* The default HitTestBehavior for the FadeButton widget has been changed from *HitTestBehavior.deferToChild* to *HitTestBehavior.opaque*. It can still be customized via the "*behavior*" argument.
 ## **0.7.2** - 14 nov 2022.
 * FadeButton now supports hovered/focused states.
 * FadeButton now supports pressing enter while focused to trigger the action.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -66,6 +66,6 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.1"
+    version: "0.7.3"
 sdks:
   dart: ">=2.18.0 <3.0.0"

--- a/lib/src/buttons/fade_button.dart
+++ b/lib/src/buttons/fade_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 
 class FadeButton extends StatefulWidget {
   final VoidCallback? onPressed;
+  final HitTestBehavior behavior;
   final Widget child;
 
   /// Determines opacity level invoked after on press action
@@ -17,6 +18,7 @@ class FadeButton extends StatefulWidget {
     Key? key,
     required this.child,
     required this.onPressed,
+    this.behavior = HitTestBehavior.opaque,
     this.pressedOpacity = 0.2,
     this.focusedOpacity = 0.6,
     this.focusNode,
@@ -30,7 +32,8 @@ class FadeButton extends StatefulWidget {
   _FadeButtonState createState() => _FadeButtonState();
 }
 
-class _FadeButtonState extends State<FadeButton> with SingleTickerProviderStateMixin {
+class _FadeButtonState extends State<FadeButton>
+    with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   static final _buttonTween = Tween<double>(begin: 1.0);
   static final _buttonCurveTween = CurveTween(curve: Curves.decelerate);
@@ -100,6 +103,7 @@ class _FadeButtonState extends State<FadeButton> with SingleTickerProviderStateM
         child: MouseRegion(
           cursor: SystemMouseCursors.click,
           child: GestureDetector(
+            behavior: widget.behavior,
             onTap: widget.onPressed,
             onTapDown: isEnabled ? (_) => _setTransparent() : null,
             onTapUp: isEnabled ? (_) => _setSolid() : null,
@@ -108,7 +112,9 @@ class _FadeButtonState extends State<FadeButton> with SingleTickerProviderStateM
               animation: _controller,
               child: widget.child,
               builder: (BuildContext context, Widget? child) => Opacity(
-                opacity: _isFocused || _isHovered ? widget.focusedOpacity : _controller.value,
+                opacity: _isFocused || _isHovered
+                    ? widget.focusedOpacity
+                    : _controller.value,
                 child: child,
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: widgets_library
 description: Widgets library
-version: 0.7.1
+version: 0.7.3
 publish_to: "none"
 
 environment:


### PR DESCRIPTION
### Changes:
- The default HitTestBehavior for the FadeButton widget has been changed from *HitTestBehavior.deferToChild* to *HitTestBehavior.opaque*. It can still be customized via the "*behavior*" argument.
- Set package version to _0.7.3_